### PR TITLE
add support for Apple M1 architecture under linux

### DIFF
--- a/src/malloy/service/service_manager.py
+++ b/src/malloy/service/service_manager.py
@@ -46,7 +46,7 @@ class ServiceManager:
     arch = platform.machine()
     if arch == "x86_64" or system == "Darwin" or system == "Windows":
       service_name += "-x64"
-    elif arch == "arm64":
+    elif arch in ("arm64", "aarch64"):
       service_name += "-arm64"
 
     if system == "Windows":


### PR DESCRIPTION
My mac with an M1 processor, running debian, lists it's architecture as "aarch64", which is equivalent to arm64. 

This fix allows malloy to run both on my mac, and most likely also under Docker on other macs