### PR TITLE
Allow service manager to be re-used

### DIFF
--- a/src/malloy/runtime.py
+++ b/src/malloy/runtime.py
@@ -63,7 +63,7 @@ class Runtime():
     return self
 
   def __exit__(self, *ex):
-    self._service_manager._kill_service()
+    self._service_manager.shutdown()
     self._was_entered = False
 
   def add_connection(self, connection: ConnectionInterface) -> Runtime:

--- a/src/malloy/service/service_manager.py
+++ b/src/malloy/service/service_manager.py
@@ -65,7 +65,8 @@ class ServiceManager:
     return self._is_ready.is_set()
 
   def shutdown(self):
-    return self._kill_service()
+    self._kill_service()
+    self._is_ready.clear()
 
   async def get_service(self):
     if not self._is_ready.is_set():

--- a/tests/malloy/service/test_service_manager.py
+++ b/tests/malloy/service/test_service_manager.py
@@ -61,6 +61,6 @@ async def test_returns_external_service_if_provided():
   assert service == external_service
 
 
-def test_kill_service_does_not_throw_if_no_proc_started():
+def test_shutdown_does_not_throw_if_no_proc_started():
   sm = ServiceManager()
   sm.shutdown()

--- a/tests/malloy/test_runtime.py
+++ b/tests/malloy/test_runtime.py
@@ -107,3 +107,30 @@ async def test_runs_sql(service_manager):
   assert data["airport_count"][0] == 1845
   assert data["state"][22] == "NC"
   assert data["airport_count"][22] == 400
+
+
+@pytest.mark.asyncio
+async def test_with():
+  with Runtime() as rt:
+    rt.add_connection(DuckDbConnection(home_dir=home_dir))
+    rt.load_file(test_file_01)
+    data = (await rt.run("duckdb", query=query_by_state)).df()
+    print(data)
+    assert data["state"][0] == "TX"
+    assert data["airport_count"][0] == 1845
+    assert data["state"][22] == "NC"
+    assert data["airport_count"][22] == 400
+
+
+@pytest.mark.asyncio
+async def test_another_with():
+  """Verify that service manager can be re-used"""
+  with Runtime() as rt:
+    rt.add_connection(DuckDbConnection(home_dir=home_dir))
+    rt.load_file(test_file_01)
+    data = (await rt.run("duckdb", query=query_by_state)).df()
+    print(data)
+    assert data["state"][0] == "TX"
+    assert data["airport_count"][0] == 1845
+    assert data["state"][22] == "NC"
+    assert data["airport_count"][22] == 400


### PR DESCRIPTION
I was a bit puzzled by why the `ServiceManager` object was being reused, until I remembered that with a default value like:
```python
  def __init__(
      self,
      connection_manager: ConnectionManagerInterface = DefaultConnectionManager(
      ),
      service_manager=ServiceManager()):
```
unlike Javascript, for all instances of `Runtime()`, `service_manager` is assigned just once, so they all will share the same service manager, so multiple instances of need to be able to restart that service manager.
```python
with Runtime() as runtime:
```

This may be the wrong approach - possibly we want to reference count or use some other mechanism to manage a service managers lifetime? Or use multiple service_managers by doing 
```python
```python
  def __init__(
      self,
      connection_manager: ConnectionManagerInterface = DefaultConnectionManager(
      ),
      service_manager=None):
    ...
    self._service_manager = service_manager or new ServiceManager()
```
?
