### PR TITLE
Make gen-services use npm ci instead of npm install

### DIFF
--- a/scripts/gen-services.sh
+++ b/scripts/gen-services.sh
@@ -2,7 +2,7 @@
 
 pushd ./submodules/malloy-service
 
-npm install && npm run build && npm run package
+npm ci && npm run build && npm run package
 
 popd
 


### PR DESCRIPTION
`npm install` does not leave a clean workspace