### PR TITLE
Reduce result processing overhead

### DIFF
--- a/src/malloy/runtime.py
+++ b/src/malloy/runtime.py
@@ -370,9 +370,9 @@ class Runtime():
     results_json = df_result.to_json(orient="records")
     self._log.debug("Sending results to service.")
     return CompileRequest(type=CompileRequest.Type.RESULTS,
-                          query_result=QueryResult(
-                              data=json.dumps(results_json),
-                              total_rows=len(df_result.index)))
+                          query_result=QueryResult(data=results_json,
+                                                   total_rows=len(
+                                                       df_result.index)))
 
   def _generate_sql_block_schemas_request(self):
     # Compiler should really be telling us which connection to use per table...


### PR DESCRIPTION
Companion to https://github.com/malloydata/malloy-service/pull/17

The result `.to_json()` is already a string, calling `json.dumps()` on it is just overhead
