### PR TITLE
Add base dir option for %%malloy_model

### DIFF
--- a/src/malloy/data/duckdb/duckdb_connection.py
+++ b/src/malloy/data/duckdb/duckdb_connection.py
@@ -68,8 +68,11 @@ class DuckDbConnection(ConnectionInterface):
     return self
 
   def with_home_dir(self, path) -> DuckDbConnection:
-    self._home_directory = path
+    self.set_home_dir(path)
     return self
+
+  def set_home_dir(self, path):
+    self._home_directory = path
 
   def get_connection(self):
     if self._con is None:

--- a/src/malloy/ipython/ipython_magic.py
+++ b/src/malloy/ipython/ipython_magic.py
@@ -113,7 +113,7 @@ async def _malloy_model(line, cell):
     return
 
   var_name = args.modelname
-  home_dir = args.data_dir
+  home_dir = args.home_dir
 
   if args.import_file:
     runtime.load_file(args.import_file)

--- a/src/malloy/ipython/ipython_magic.py
+++ b/src/malloy/ipython/ipython_magic.py
@@ -73,6 +73,11 @@ model_arg_parser.add_argument("-i",
                               required=False,
                               dest="import_file")
 
+model_arg_parser.add_argument("-d",
+                              "--home_dir",
+                              required=False,
+                              dest="home_dir")
+
 # Argument parser for the %%malloy_query magic
 query_arg_parser = MalloyMagicArgumentParser(
     prog="%%malloy_query",
@@ -108,11 +113,12 @@ async def _malloy_model(line, cell):
     return
 
   var_name = args.modelname
+  home_dir = args.data_dir
 
   if args.import_file:
     runtime.load_file(args.import_file)
   else:
-    runtime.load_source("\n" + cell)
+    runtime.load_source("\n" + cell, import_path=home_dir)
 
   try:
     model = await runtime.compile_model()

--- a/src/malloy/runtime.py
+++ b/src/malloy/runtime.py
@@ -351,6 +351,11 @@ class Runtime():
         self._log.debug("  default connection: %s", connection_name)
 
       connection = self._connection_manager.get_connection(connection_name)
+
+      set_home_dir = getattr(connection, "set_home_dir", None)
+      if callable(set_home_dir):
+        set_home_dir(self._file_dir)
+
       if connection:
         # tables = tables_per_connection_to_fetch.get(connection)
         self._log.debug("  tables: %s", tables)


### PR DESCRIPTION
Allow user to specify a home_dir to use when defining a %%malloy_model through source.

This will also call `set_home_dir` on the connection if it is available, to set the home directory for the connection to use when looking for data sources.