### PR TITLE
Update malloy version.

### DIFF
--- a/src/malloy/data/bigquery/bq_connection.py
+++ b/src/malloy/data/bigquery/bq_connection.py
@@ -143,7 +143,7 @@ class BigQueryConnection(ConnectionInterface):
         },
         "structRelationship": {
             "type": "nested",
-            "field": name,
+            "fieldName": name,
             "isArray": False
         } if mode == "REPEATED" else {
             "type": "inline"
@@ -167,7 +167,7 @@ class BigQueryConnection(ConnectionInterface):
       elif metadata.field_type in self.TYPE_MAP:
         field |= self.TYPE_MAP[metadata.field_type]
       else:
-        field["type"] = "unsupported"
+        field["type"] = "sql native"
         field["rawType"] = metadata.field_type.lower()
       fields.append(field)
 
@@ -191,7 +191,7 @@ class BigQueryConnection(ConnectionInterface):
       elif schema_field["type"] in self.TYPE_MAP:
         field |= self.TYPE_MAP[schema_field["type"]]
       else:
-        field["type"] = "unsupported"
+        field["type"] = "sql native"
         field["rawType"] = schema_field["type"].lower()
       fields.append(field)
 

--- a/src/malloy/data/duckdb/duckdb_connection.py
+++ b/src/malloy/data/duckdb/duckdb_connection.py
@@ -184,7 +184,7 @@ class DuckDbConnection(ConnectionInterface):
             },
             "structRelationship": {
                 "type": "nested" if is_array else "inline",
-                "field": name,
+                "fieldName": name,
                 "isArray": False,
             },
             "fields": self._map_fields(sub_schema),
@@ -205,7 +205,7 @@ class DuckDbConnection(ConnectionInterface):
               },
               "structRelationship": {
                   "type": "nested",
-                  "field": name,
+                  "fieldName": name,
                   "isArray": True,
               },
               "fields": [{

--- a/src/malloy/utils/third_party_licenses.py
+++ b/src/malloy/utils/third_party_licenses.py
@@ -174,7 +174,7 @@ SPECIAL_CASES = {
     },
     'uri-template': {
         METADATA_URL:
-            'https://gitlab.linss.com/open-source/python/uri-template/-',
+            'https://github.com/plinss/uri-template',
         METADATA_LICENSE_FILE:
             'LICENSE'
     },

--- a/src/malloy/utils/third_party_licenses.py
+++ b/src/malloy/utils/third_party_licenses.py
@@ -173,10 +173,8 @@ SPECIAL_CASES = {
         METADATA_NAME: 'typing_extensions'
     },
     'uri-template': {
-        METADATA_URL:
-            'https://github.com/plinss/uri-template',
-        METADATA_LICENSE_FILE:
-            'LICENSE'
+        METADATA_URL: 'https://github.com/plinss/uri-template',
+        METADATA_LICENSE_FILE: 'LICENSE'
     },
     'webencodings': {
         METADATA_LICENSE_FILE: 'LICENSE'

--- a/src/malloy/utils/third_party_licenses.py
+++ b/src/malloy/utils/third_party_licenses.py
@@ -84,6 +84,9 @@ SPECIAL_CASES = {
     'grpcio-tools': {
         METADATA_LICENSE_FILE: 'LICENSE'
     },
+    'jinja2': {
+        METADATA_LICENSE_FILE: 'LICENSE.txt'
+    },
     'jaraco-classes': {
         METADATA_NAME: 'jaraco.classes'
     },
@@ -114,6 +117,9 @@ SPECIAL_CASES = {
     },
     'markdown-it-py': {
         METADATA_LICENSE_FILE: 'LICENSE'
+    },
+    'markupsafe': {
+        METADATA_LICENSE_FILE: 'LICENSE.txt'
     },
     'more-itertools': {
         METADATA_LICENSE_FILE: 'LICENSE'

--- a/tests/malloy/test_runtime.py
+++ b/tests/malloy/test_runtime.py
@@ -90,10 +90,10 @@ async def test_returns_sql(service_manager):
   [sql, connection] = await rt.get_sql(query=query_by_state)
   assert (sql == """
 SELECT\x20
-   airports."state" as "state",
+   base."state" as "state",
    COUNT(1) as "airport_count"
-FROM 'data/airports.parquet' as airports
-WHERE airports."state" IS NOT NULL
+FROM 'data/airports.parquet' as base
+WHERE base."state" IS NOT NULL
 GROUP BY 1
 ORDER BY 2 desc NULLS LAST
 """.lstrip())


### PR DESCRIPTION
Updates malloy-service version.

Also includes changes to bring connection schemas up to date with latest PRs:
* https://github.com/malloydata/malloy/pull/1791
  * `unsupported` => `sql native`
* https://github.com/malloydata/malloy/pull/1561
  * structRelationship property `field` renamed to `fieldName` 
* https://github.com/malloydata/malloy/pull/1734
  * starting alias for table is now `base`   