### PR TITLE
Fix Mac Silicon bug: service_manager.py incorrectly selects x64 binary on Apple Silicon Macs 

### DIFF
--- a/src/malloy/service/service_manager.py
+++ b/src/malloy/service/service_manager.py
@@ -54,7 +54,7 @@ class ServiceManager:
       service_name += "-macos"
 
     arch = platform.machine()
-    if arch == "x86_64" or system == "Darwin" or system == "Windows":
+    if arch == "x86_64" or system == "Windows":
       service_name += "-x64"
     elif arch in ("arm64", "aarch64"):
       service_name += "-arm64"


### PR DESCRIPTION
The ServiceManager.service_path() method had a logic bug that caused Mac computers with Apple Silicon (M1/M2/M3/M4) chips to incorrectly receive the x64 service binary instead of the arm64 binary. This would result in the wrong architecture binary being loaded, leading to potential crashes or failures.

The changes were done completely by github copilot in this [PR](https://github.com/vigneshc/malloy-py/pull/1).
